### PR TITLE
Sanitize search query to prevent SQL injection

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -8,8 +8,8 @@ class RecipesController < ApplicationController
     params[:page]? @page = params[:page] : @page = 1
 
     if params[:ingredients]
-      @total_recipes = Recipe.where(Recipe.search_query(params[:ingredients])).count
-      @recipes = Recipe.where(Recipe.search_query(params[:ingredients])).includes(:author, :category).order(created_at: :desc).page(@page)
+      @total_recipes = Recipe.search_by_ingredients(params[:ingredients],only_count=true)
+      @recipes = Recipe.search_by_ingredients(params[:ingredients])
     else
       @total_recipes = Recipe.all.count
       @recipes = Recipe.all.includes(:author, :category).order(created_at: :desc).page(@page)
@@ -54,9 +54,6 @@ class RecipesController < ApplicationController
 
   # PATCH/PUT /recipes/1 or /recipes/1.json
   def update
-    p "==="
-    p recipe_params
-    p "==="
     respond_to do |format|
       if @recipe.update(recipe_params)
         format.html { redirect_to recipe_url(@recipe), notice: "Recipe was successfully updated." }

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -9,21 +9,30 @@ class Recipe < ApplicationRecord
   validates :category_id, presence: true
 
   # Build full-text search query that contains one or several ingredients
-  def self.search_query(ingredients)
+  def self.search_by_ingredients(ingredients,only_count=false)
     search_query = ""
 
     if ingredients.include? ","
       searchterms = ingredients.split(",")
-
       searchterms.each_with_index do |val, index|
         if index > 0
           search_query << " AND "
         end
-        search_query << "ingredients @? '$[*] ? (@ like_regex \"#{val}\" flag \"i\")'"
+        sanitized_query = sanitize_for_query("(@ like_regex \"%s\" flag \"i\")'", val)
+        search_query << "ingredients @? '$[*] ? " + sanitized_query.to_s
       end
     else
-      search_query = "ingredients @? '$[*] ? (@ like_regex \"#{ingredients}\" flag \"i\")'"
+      sanitized_query = sanitize_for_query("(@ like_regex \"%s\" flag \"i\")'", ingredients)
+      search_query << "ingredients @? '$[*] ? " + sanitized_query.to_s
     end
-    @query = search_query
+    if only_count
+      @recipes = Recipe.where(search_query).includes(:author, :category).order(created_at: :desc).count
+    else
+      @recipes = Recipe.where(search_query).includes(:author, :category).order(created_at: :desc).page(@page)
+    end
+  end
+
+  def self.sanitize_for_query(exp,val)
+    ActiveRecord::Base::sanitize_sql_for_conditions([exp, val])
   end
 end


### PR DESCRIPTION
- Sanitize search query to prevent SQL injection, by using `ActiveRecord::Base::sanitize_sql_for_conditions` on full-time search queries
- Refactor Recipe model auxiliary methods
- Simplify recipes_controller